### PR TITLE
Fix initial excess delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ let shared_sem = sync::Arc::new(
 // This is a counter that increments when a thread completed
 let shared_done_count = sync::Arc::new(sync::Mutex::new(0));
 
-// Spawn 10 threads
-for _ in 0..10 {
+// Spawn 15 threads
+for _ in 0..15 {
     let cloned_sem = shared_sem.clone();
     let cloned_done_state = shared_done_count.clone();
     let thread = thread::spawn(move || {
@@ -46,15 +46,15 @@ for _ in 0..10 {
     });
 }
 
-// So sleep 1 second
-thread::sleep(time::Duration::new(1, 0));
+// So sleep 1 second (add some millis to let threads complete incrementing)
+thread::sleep(time::Duration::from_secs(1) + time::Duration::from_millis(50));
 let cloned_done_count = shared_done_count.clone();
 let current_done = cloned_done_count.lock().unwrap();
 
-// And then maximum 5 threads should be completed
+// And then maximum 10 threads should be completed
 // after 1 second sleeping
-// (<= for clocks infelicity)
-assert_eq!(*current_done <= 5, true);
+// (the first 5 with no delay and the another 5 after 1 second)
+assert_eq!(*current_done, 10);
 ```
 
 ## Features

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -21,8 +21,8 @@ use std::time::{Duration, Instant};
 /// // This is a counter that increments when a thread completed
 /// let shared_done_count = sync::Arc::new(sync::Mutex::new(0));
 ///
-/// // Spawn 10 threads
-/// for _ in 0..10 {
+/// // Spawn 15 threads
+/// for _ in 0..15 {
 ///     let cloned_sem = shared_sem.clone();
 ///     let cloned_done_state = shared_done_count.clone();
 ///     let thread = thread::spawn(move || {
@@ -45,14 +45,15 @@ use std::time::{Duration, Instant};
 ///     });
 /// }
 ///
-/// // So sleep 3 seconds
-/// thread::sleep(time::Duration::new(1, 0));
+/// // So sleep 1 second (add some millis to let threads complete incrementing)
+/// thread::sleep(time::Duration::from_secs(1) + time::Duration::from_millis(50));
 /// let cloned_done_count = shared_done_count.clone();
 /// let current_done = cloned_done_count.lock().unwrap();
 ///
-/// // And then maximum 5 threads should be completed
+/// // And then maximum 10 threads should be completed
 /// // after 1 second sleeping
-/// assert_eq!(*current_done <= 5, true);
+/// // (the first 5 with no delay and the another 5 after 1 second)
+/// assert_eq!(*current_done == 10, true);
 /// ```
 #[derive(Debug, Clone)]
 pub struct Semaphore {
@@ -81,10 +82,10 @@ impl Semaphore {
     /// use std::time::Duration;
     /// use raliguard::Semaphore;
     ///
-    /// // 5 executions per 1 second
+    /// // Allows 5 executions per 1 second
     /// let semaphore = Semaphore::new(5, Duration::from_secs(1));
     ///
-    /// // 2 executions per 7 seconds
+    /// // Allows 2 executions per 7 seconds
     /// let semaphore = Semaphore::new(2, Duration::from_secs(7));
     /// ```
     pub fn new(access_times: u64, per_period: Duration) -> Self {
@@ -111,16 +112,19 @@ impl Semaphore {
             return None;
         }
 
+        // Add new hit
         self.current_block_access += 1;
-        let delay = self.boundary - stamp;
+
+        // Calc delay, should not be at all if it's the first block
+        let delay = (self.boundary - stamp).checked_sub(self.per_period);
 
         // Allowed access for current block gets it's maximum,
-        // shoul move block forward
+        // should move block forward
         if self.current_block_access == self.access_times {
             self.boundary += self.per_period;
             self.current_block_access = 0;
         }
 
-        Some(delay)
+        delay
     }
 }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -53,7 +53,7 @@ use std::time::{Duration, Instant};
 /// // And then maximum 10 threads should be completed
 /// // after 1 second sleeping
 /// // (the first 5 with no delay and the another 5 after 1 second)
-/// assert_eq!(*current_done == 10, true);
+/// assert_eq!(*current_done, 10);
 /// ```
 #[derive(Debug, Clone)]
 pub struct Semaphore {


### PR DESCRIPTION
There was an excess delay when semaphore's state at renewed boundary stamp. Now it was fixed, so first `access_times` requests will be executed with no delay, and next will have delay only when they exceed limit