### PR TITLE
Fix calc_delay when access_times is 1

### DIFF
--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -1,7 +1,6 @@
 /// Implementation of rate limi semaphore
 use std::time::{Duration, Instant};
 
-
 /// Use it to control execution frequency
 ///
 /// # Examples:
@@ -62,9 +61,8 @@ pub struct Semaphore {
 
     boundary: Duration,
     current_block_access: u64,
-    benchmark_stamp: Instant
+    benchmark_stamp: Instant,
 }
-
 
 impl Semaphore {
     /// Create a new semaphore
@@ -108,8 +106,7 @@ impl Semaphore {
         // Boundary second should be moved forward if it's outdated
         if stamp >= self.boundary {
             self.boundary = stamp + self.per_period;
-            self.current_block_access = 1;
-            return None;
+            self.current_block_access = 0;
         }
 
         // Add new hit

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,17 +1,13 @@
-use std::{thread, time, sync};
+use std::{sync, thread, time};
 
 use crate::Semaphore;
 
-#[test]
-fn check_limit_not_exceeded() {
-    let originl_sem = Semaphore::new(3, time::Duration::from_secs(1));
-    let shared_sem = sync::Arc::new(
-        sync::Mutex::new(originl_sem)
-    );
-
-    let shared_done_count = sync::Arc::new(sync::Mutex::new(0));
-
-    for _ in 0..15 {
+fn spawn_threads(
+    num_threads: i32,
+    shared_sem: &sync::Arc<sync::Mutex<Semaphore>>,
+    shared_done_count: &sync::Arc<sync::Mutex<i32>>,
+) {
+    for _ in 0..num_threads {
         let cloned_sem = shared_sem.clone();
         let cloned_done_state = shared_done_count.clone();
         thread::spawn(move || {
@@ -27,9 +23,17 @@ fn check_limit_not_exceeded() {
 
             let mut local_done_count = cloned_done_state.lock().unwrap();
             *local_done_count += 1;
-
         });
     }
+}
+
+#[test]
+fn check_limit_not_exceeded_multiple_access_times() {
+    let originl_sem = Semaphore::new(3, time::Duration::from_secs(1));
+    let shared_sem = sync::Arc::new(sync::Mutex::new(originl_sem));
+    let shared_done_count = sync::Arc::new(sync::Mutex::new(0));
+
+    spawn_threads(15, &shared_sem, &shared_done_count);
 
     // Add some millis because of working freeze
     let one_second = time::Duration::from_secs(1) + time::Duration::from_millis(50);
@@ -51,4 +55,34 @@ fn check_limit_not_exceeded() {
     let current_done = cloned_done_count.lock().unwrap();
 
     assert_eq!(*current_done, 12);
+}
+
+#[test]
+fn check_limit_not_exceeded_single_access_time() {
+    let originl_sem = Semaphore::new(1, time::Duration::from_secs(1));
+    let shared_sem = sync::Arc::new(sync::Mutex::new(originl_sem));
+    let shared_done_count = sync::Arc::new(sync::Mutex::new(0));
+
+    spawn_threads(15, &shared_sem, &shared_done_count);
+
+    // Add some millis because of working freeze
+    let one_second = time::Duration::from_secs(1) + time::Duration::from_millis(50);
+
+    // Maximum 2 threads should be completed (1 with no delay at 1 after a second)
+    thread::sleep(one_second);
+    let cloned_done_count = shared_done_count.clone();
+    let current_done = cloned_done_count.lock().unwrap();
+
+    assert_eq!(*current_done, 2);
+
+    // Let other thread to write there again
+    drop(current_done);
+
+    // Now 4 threads should be completed, because 2 seconds passed
+    // And 2 more threads should be completed
+    thread::sleep(one_second * 2);
+    let cloned_done_count = shared_done_count.clone();
+    let current_done = cloned_done_count.lock().unwrap();
+
+    assert_eq!(*current_done, 4);
 }


### PR DESCRIPTION
When access_times is equal to 1, calc_delay fails due to getting into a state where current_block_access exceeds 1, but the check of whether the block is full uses ==. Avoid this situation by removing the shortcut logic if the boundary is outdated. Note that simply checking >= on the next round is not enough as the boundary won't be updated after the first run.

Also added a new unit test for this case.